### PR TITLE
Add cell_path handling to TFM utilities

### DIFF
--- a/notebooks/Full_TFM_UNet_Pipeline.ipynb
+++ b/notebooks/Full_TFM_UNet_Pipeline.ipynb
@@ -46,7 +46,7 @@
    "id": "ed0f98a2",
    "metadata": {},
    "source": [
-    "## Step 1–2: Process Each Cell and Stack `.npy`"
+    "## Step 1\u20132: Process Each Cell and Stack `.npy`"
    ]
   },
   {
@@ -65,7 +65,7 @@
     "    print(f\"Processing {folder}...\")\n",
     "\n",
     "    # TFM steps\n",
-    "    TFM_Image_registration.TFM_Image_registration(cell_path, cell_path)\n",
+    "    TFM_Image_registration.TFM_Image_registration(cell_path)\n",
     "    TFM_displacement_tools.TFM_optical_flow(cell_path)\n",
     "    TFM_tools.TFM_calculation(cell_path)\n",
     "    TFM_tools.cellmask_threshold(cell_path)\n",

--- a/tfm/TFM_Image_registration.py
+++ b/tfm/TFM_Image_registration.py
@@ -3,6 +3,7 @@
 import glob as glob                                  		 # for finding files in the folder
 import skimage.io as io                              		 # for reading/writing images
 import numpy as np                                   		 # for math operations
+import os                                                        # for handling directories
 from scipy.fftpack import fft2, ifft2, ifftshift     		 # for fourier transform operations
 from skimage.registration import phase_cross_correlation     # registration function
 
@@ -27,7 +28,9 @@ def flat_field_correct_image(image, flat_field_image, dark_image):
         
     return corrected_image
 
-def TFM_Image_registration(flatfield_correct = False, image_list = None, flatfield_images = None, darkfield_image = None):
+def TFM_Image_registration(cell_path='.', flatfield_correct = False, image_list = None, flatfield_images = None, darkfield_image = None):
+    current_dir = os.getcwd()
+    os.chdir(cell_path)
 
     # Check if images are to be corrected
     if flatfield_correct:
@@ -153,7 +156,8 @@ def TFM_Image_registration(flatfield_correct = False, image_list = None, flatfie
                 shift_image_stack(image_name, shift_coordinates, flatfield_images[i+1], darkfield_image, correct_odd_imagesize = True)
             else:
                 shift_image_stack(image_name, shift_coordinates, correct_odd_imagesize = True)
-                      
+
+    os.chdir(current_dir)
     return
 
 def shift_image_stack(image_stack_name, shift_coordinates, flatfield_image =  None, darkfield_image = None, correct_odd_imagesize = True):

--- a/tfm/TFM_displacement_tools.py
+++ b/tfm/TFM_displacement_tools.py
@@ -7,7 +7,9 @@ import glob as glob                                            # for finding fil
 import os                                                      # for making directory to store displacement files
 
 
-def TFM_optical_flow(pyr_scale = 0.25, levels = 4, winsize = 24, iterations = 4, poly_n = 7, poly_sigma = 1.25):
+def TFM_optical_flow(cell_path='.', pyr_scale = 0.25, levels = 4, winsize = 24, iterations = 4, poly_n = 7, poly_sigma = 1.25):
+    current_dir = os.getcwd()
+    os.chdir(cell_path)
     # Create a dictionary of our PIV parameters
     PIV_params = {
     "method" : 'Farneback Optical Flow',
@@ -60,4 +62,5 @@ def TFM_optical_flow(pyr_scale = 0.25, levels = 4, winsize = 24, iterations = 4,
         io.imsave('displacement_files/disp_v_%03d.tif' % (t), flow[:,:,1], check_contrast=False)
 
 
+    os.chdir(current_dir)
     return

--- a/tfm/TFM_tools.py
+++ b/tfm/TFM_tools.py
@@ -18,7 +18,9 @@ from TFM_FTTC_tools import *
 
 
 
-def TFM_calculation(shear_modulus = 8600, um_per_pixel = .103174, regparam = 1e-16, downsample = 12, timepoint = 1, check_figure=False, fig_max_stress = 1000):
+def TFM_calculation(cell_path='.', shear_modulus = 8600, um_per_pixel = .103174, regparam = 1e-16, downsample = 12, timepoint = 1, check_figure=False, fig_max_stress = 1000):
+    current_dir = os.getcwd()
+    os.chdir(cell_path)
     # Find the displacement files
     file_list_dispu = sorted(glob.glob('displacement_files/disp_u*.tif'))
     file_list_dispv = sorted(glob.glob('displacement_files/disp_v*.tif'))
@@ -192,7 +194,8 @@ def TFM_calculation(shear_modulus = 8600, um_per_pixel = .103174, regparam = 1e-
         TFM_check_axes[1,3].axis('off')
         TFM_check_fig.tight_layout()
         TFM_check_fig.show()
-    return 
+    os.chdir(current_dir)
+    return
 
 
 def TFM_analysis(GFP='', force_min=0):
@@ -323,7 +326,9 @@ def TFM_analysis(GFP='', force_min=0):
 
     return
 
-def cellmask_threshold(imagename, small_object_size=50, cell_minimum_area=50000, dilation_size = 10, save_figure=True, plot_figure=True, timepoint = 0):
+def cellmask_threshold(cell_path='.', imagename='561short_registered.tif', small_object_size=50, cell_minimum_area=50000, dilation_size = 10, save_figure=True, plot_figure=True, timepoint = 0):
+    current_dir = os.getcwd()
+    os.chdir(cell_path)
     # check if it's a string or a matrix and read in the image
     if isinstance(imagename, str):
         imagestack = io.imread(imagename, plugin='tifffile', is_ome=False)
@@ -470,6 +475,7 @@ def cellmask_threshold(imagename, small_object_size=50, cell_minimum_area=50000,
         cellmask_stack = cellmask_stack[0]
         forcemask_stack = forcemask_stack[0]
 
+    os.chdir(current_dir)
     return cellmask_stack, forcemask_stack, threshold
 
 


### PR DESCRIPTION
## Summary
- add optional `cell_path` argument to `TFM_Image_registration`, `TFM_optical_flow`, `TFM_calculation` and `cellmask_threshold`
- change these utilities to `os.chdir` into `cell_path`
- update example notebook to call the new signatures

## Testing
- `python3 -m py_compile tfm/TFM_Image_registration.py tfm/TFM_displacement_tools.py tfm/TFM_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_684694e01234832483f201f9fd2c0403