### PR TITLE
Ensure files exist before tfm processing

### DIFF
--- a/tfm/TFM_FTTC_tools.py
+++ b/tfm/TFM_FTTC_tools.py
@@ -7,6 +7,7 @@ from scipy.sparse import spdiags, csr_matrix, linalg           # sparse matrix a
 import matplotlib.pyplot as plt                                # for plotting
 import glob as glob                                            # grabbing file names
 import skimage.io as io                                        # reading in images
+import os
 import openpiv.pyprocess
 import scipy.sparse as sparse
 import scipy.linalg as linalg
@@ -256,8 +257,12 @@ def calculate_energy(u, f, pix_per_mu, mesh_size):
 
 def find_regularization_parameter(shear_modulus = 16000):
     # calculate the best regularization parameter
-    ux = io.imread('displacement_files/disp_u_001.tif')
-    uy = io.imread('displacement_files/disp_v_001.tif')
+    disp_u_file = 'displacement_files/disp_u_001.tif'
+    disp_v_file = 'displacement_files/disp_v_001.tif'
+    if not os.path.isfile(disp_u_file) or not os.path.isfile(disp_v_file):
+        raise FileNotFoundError('Required displacement files not found')
+    ux = io.imread(disp_u_file)
+    uy = io.imread(disp_v_file)
     u = np.zeros((2,ux.shape[0],ux.shape[1]))
     u[0,:,:] = ux
     u[1,:,:] = uy

--- a/tfm/TFM_Image_registration.py
+++ b/tfm/TFM_Image_registration.py
@@ -48,6 +48,8 @@ def TFM_Image_registration(cell_path='.', flatfield_correct = False, image_list 
     # check if reference has already been corrected
     original_reference_image = glob.glob('*reference_original.tif')
     if len(original_reference_image) > 0:
+        if not os.path.isfile(original_reference_image[0]):
+            raise FileNotFoundError(f"Expected reference image '{original_reference_image[0]}' not found")
         reference_image = io.imread(original_reference_image[0], plugin='tifffile', is_ome=False)
         # Correct the reference image
         if flatfield_correct:
@@ -58,6 +60,10 @@ def TFM_Image_registration(cell_path='.', flatfield_correct = False, image_list 
     else:
         # Otherwise find and read in your reference image
         file_list = glob.glob('*_reference.tif')
+        if len(file_list) == 0:
+            raise FileNotFoundError("No '*_reference.tif' image found")
+        if not os.path.isfile(file_list[0]):
+            raise FileNotFoundError(f"Expected reference image '{file_list[0]}' not found")
         reference_image = io.imread(file_list[0], plugin='tifffile', is_ome=False)
         # Correct the reference image
         if flatfield_correct:
@@ -69,7 +75,10 @@ def TFM_Image_registration(cell_path='.', flatfield_correct = False, image_list 
     N_cols = reference_image.shape[1]
 
     # read in your bead image
-    image_stack = io.imread(file_name + '.tif')
+    bead_file = file_name + '.tif'
+    if not os.path.isfile(bead_file):
+        raise FileNotFoundError(f"Bead stack '{bead_file}' not found")
+    image_stack = io.imread(bead_file)
 
     # correct the stack shape if there's only one image
     if len(image_stack.shape) == 2:
@@ -128,6 +137,8 @@ def TFM_Image_registration(cell_path='.', flatfield_correct = False, image_list 
         # check if the original reference image file has been saved
         ref_original = glob.glob('*reference_original.tif')
         ref_im = glob.glob('*_reference.tif')
+        if len(ref_im) == 0 or not os.path.isfile(ref_im[0]):
+            raise FileNotFoundError("Reference image for size correction not found")
         reference_image = io.imread(ref_im[0])
         if len(ref_original) == 0:
             io.imsave(ref_im[0][:-4] + '_original.tif', reference_image, check_contrast=False)
@@ -137,6 +148,8 @@ def TFM_Image_registration(cell_path='.', flatfield_correct = False, image_list 
         # check if the original reference image file has been saved
         ref_original = glob.glob('*reference_original.tif')
         ref_im = glob.glob('*_reference.tif')
+        if len(ref_im) == 0 or not os.path.isfile(ref_im[0]):
+            raise FileNotFoundError("Reference image for size correction not found")
         reference_image = io.imread(ref_im[0])
         if len(ref_original) == 0:
             io.imsave(ref_im[0][:-4] + '_original.tif', reference_image, check_contrast=False)
@@ -177,6 +190,8 @@ def shift_image_stack(image_stack_name, shift_coordinates, flatfield_image =  No
     """
     
     # read in image stack
+    if not os.path.isfile(image_stack_name):
+        raise FileNotFoundError(f"Image stack '{image_stack_name}' not found")
     image_stack = io.imread(image_stack_name, plugin='tifffile', is_ome=False).astype('int16')
     
     # correct the stack shape if there's only one image

--- a/tfm/TFM_displacement_tools.py
+++ b/tfm/TFM_displacement_tools.py
@@ -30,6 +30,10 @@ def TFM_optical_flow(cell_path='.', pyr_scale = 0.25, levels = 4, winsize = 24, 
 
     # read in reference image
     ref_file_list = glob.glob('*_reference.tif')
+    if len(ref_file_list) == 0:
+        raise FileNotFoundError("No '*_reference.tif' image found")
+    if not os.path.isfile(ref_file_list[0]):
+        raise FileNotFoundError(f"Expected reference image '{ref_file_list[0]}' not found")
     reference_image = io.imread(ref_file_list[0])
 
     # make a directory to store all the displacement files
@@ -37,7 +41,10 @@ def TFM_optical_flow(cell_path='.', pyr_scale = 0.25, levels = 4, winsize = 24, 
         os.mkdir('displacement_files/')
 
     # read in image stack
-    image_stack = io.imread(ref_file_list[0][:-14] + '_registered.tif')
+    stack_file = ref_file_list[0][:-14] + '_registered.tif'
+    if not os.path.isfile(stack_file):
+        raise FileNotFoundError(f"Registered bead stack '{stack_file}' not found")
+    image_stack = io.imread(stack_file)
 
     # correct the stack shape if there's only one image
     if len(image_stack.shape) == 2:


### PR DESCRIPTION
## Summary
- add file existence checks before reading images in tfm modules
- raise helpful errors early when required files are missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846995e81048324b703cabafb0f4702