### PR TITLE
Remove unused imports

### DIFF
--- a/tfm/TFM_FTTC_tools.py
+++ b/tfm/TFM_FTTC_tools.py
@@ -3,15 +3,11 @@ import numpy as np                                             # basic math
 from scipy.fft import fft2, ifft2, ifftshift               # FFT for image registration
 from scipy.interpolate import griddata, SmoothBivariateSpline  # Interpolation for fixing bad PIV vectors
 from scipy import optimize                                     # curve fitting
-from scipy.sparse import spdiags, csr_matrix, linalg           # sparse matrix algebra
 import matplotlib.pyplot as plt                                # for plotting
 import glob as glob                                            # grabbing file names
 import skimage.io as io                                        # reading in images
 import os
-import openpiv.pyprocess
 import scipy.sparse as sparse
-import scipy.linalg as linalg
-from scipy import optimize                                     # curve fitting
 try:
     from sksparse.cholmod import cholesky_AAt
 except:

--- a/utils/UNeXt.py
+++ b/utils/UNeXt.py
@@ -1,10 +1,7 @@
-import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as pltclr
 
-from time import time
-import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/utils/base_layers.py
+++ b/utils/base_layers.py
@@ -1,7 +1,5 @@
-from time import time
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class SinAct(nn.Module):

--- a/utils/data_processing.py
+++ b/utils/data_processing.py
@@ -12,7 +12,6 @@ from torchvision import transforms
 from torch.utils.data.sampler import SubsetRandomSampler
 from skimage import filters
 from skimage import morphology
-from time import time
 
 import warnings
 warnings.filterwarnings("ignore")

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -1,12 +1,10 @@
 import os
 import sys
 import pickle
-import pickle
 #from natsort import natsorted
 import numpy as np
 import pandas as pd
 import torch
-import torch.nn.functional as F
 import time
 from datetime import datetime
 import scipy.ndimage
@@ -15,7 +13,6 @@ from skimage.measure import label, regionprops, regionprops_table
 
 from utils.utils_data_processing_base import SubsetSampler
 
-import matplotlib.pyplot as plt
 import matplotlib
 matplotlib.use('Agg')
 import skimage

--- a/utils/old_utils_data_processing.py
+++ b/utils/old_utils_data_processing.py
@@ -11,7 +11,6 @@ from torchvision import transforms
 from torch.utils.data.sampler import SubsetRandomSampler
 from skimage import filters
 from skimage import morphology
-from time import time
 
 import warnings
 warnings.filterwarnings("ignore")

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import matplotlib.colors as mplcolors
 import numpy as np
 import skimage.measure as measure


### PR DESCRIPTION
## Summary
- clean up duplicate and unused imports across modules
- run ruff linter

## Testing
- `ruff check tfm/TFM_FTTC_tools.py utils/eval.py utils/UNeXt.py utils/base_layers.py utils/data_processing.py utils/old_utils_data_processing.py utils/plot.py`

------
https://chatgpt.com/codex/tasks/task_e_68469bd262248324bd8288483b4f8d8f