### PR TITLE
Add memory-return options for TFM functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ pip install -r requirements.txt
 ### Workflow Summary
 1. **Register beads** and compute displacements using scripts in `tfm/`.
 2. **Calculate traction maps** with `TFM_calculation` and generate masks.
+   The core functions now accept `save_files=False` to return arrays directly
+   without writing to disk.
 3. **Assemble training stacks** via the notebooks in `notebooks/`.
 4. **Train** the U-Net (`train_unet.ipynb`) and **predict** new force maps.
 


### PR DESCRIPTION
## Summary
- allow TFM_Image_registration, TFM_optical_flow and TFM_calculation to return arrays in memory
- gate disk output with a `save_files` flag
- mention new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a1355e54832489759791a9177ae0