### PR TITLE
Fix: Make cellstress_venv.yml file portable

### DIFF
--- a/cellstress_venv.yml
+++ b/cellstress_venv.yml
@@ -1,4 +1,4 @@
-name: /project/vitelli/ml_venv
+name: cellstress_env
 channels:
   - anaconda
   - pytorch
@@ -541,4 +541,3 @@ dependencies:
 variables:
   NUMEXPR_MAX_THREADS: '1'
   OMP_NUM_THREADS: '1'
-prefix: /project/vitelli/ml_venv


### PR DESCRIPTION
The environment.yml file previously contained a hardcoded, machine-specific prefix and an absolute path for the environment name. This prevented other users from successfully creating the Conda environment on their local machines.

This commit resolves the issue by:
- Removing the `prefix` line entirely.
- Changing the `name` from an absolute path to a generic name (`cellstress_env`).

These changes make the environment configuration portable and ensure that any contributor can easily and reliably set up the project's dependencies.